### PR TITLE
Use raw color string if no readable one is defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![](https://img.shields.io/badge/dependencies-none-brightgreen.svg)
 [![Build Status](https://travis-ci.org/irhc/js-logging.svg?branch=master)](https://travis-ci.org/irhc/js-logging)
 
-A powerful, feature rich and customizable logging library for node.js and any browser with a console. 
+A powerful, feature rich and customizable logging library for node.js and any browser with a console.
 
 This library is based on baryon's node.js logging library [tracer](https://github.com/baryon/tracer). It has no dependencies, predefined settings and its default log levels are
 compliant with RFC 5424.
@@ -26,7 +26,7 @@ On the server side (e.g. nodejs) an example looks like this
 npm install js-logging
 ```
 ```javascript
-// use predefined console logger (function console) with standard settings 
+// use predefined console logger (function console) with standard settings
 let logger1 = require('js-logging').console();
 logger1.debug('Hello World!');
 
@@ -42,7 +42,7 @@ Current version should work with Node.js version 6.0 and above.
 ```javascript
 <script src='js-logging.browser.js'></script>
 <script>
-	// use predefined color console logger (function colorConsole) with standard settings 
+	// use predefined color console logger (function colorConsole) with standard settings
 	let logger1 = Logging.colorConsole();
 	logger1.debug('Hello World!');
 
@@ -84,7 +84,7 @@ logger.debug('Hello World!');
 
 - 2) colorConsole
 ```javascript
-// the predefined function generates a new object of the Logging class with color settings 
+// the predefined function generates a new object of the Logging class with color settings
 // by the use of the option filters
 let logger = require('js-logging').colorConsole([options]);
 logger.debug('Hello World!');
@@ -92,7 +92,7 @@ logger.debug('Hello World!');
 let conf = {
 	filters: {
     	debug: 'white',
-        info: 'yellow',
+        info: '\x1b[33m',
         notice: 'green',
         warning: 'blue',
         error: 'red',
@@ -113,7 +113,7 @@ logger.debug('Hello World!');
 ```javascript
 // the predefined function generates a new object of the Logging class with file transport, rotating daily.
 let logger = require('../js-logging.umd.js').dailyFile([options]);
-logger.debug('Hello World!'); 
+logger.debug('Hello World!');
 ```
 
 ###Usage browser
@@ -143,33 +143,33 @@ let defaultOptions = {
 	// pos, path, method, stack
 	// see the data object description for there meanings
     format: "${timestamp} <${title}> ${file}:${line} ${method} ${message}",
-	
+
 	// every format according to Steven Levithan's excellent dateFormat() function is possible
     dateformat: "isoDateTime",
-	
+
 	// manipulate the data object before any transport
     preprocess: function (data) {
     },
-	
+
 	// define one or multiple transports by the use of the data object (see the example mulitpleTransport.js)
     transport: function (data) {
         console.log(data.output);
     },
-	
+
 	// can be an array of color strings or functions
 	// node.js colors: black, red, green, yellow, blue, magenta, cyan and white
 	// browser colors: any css color
 	// the last item can be a custom filter object where each method can be overridden indiviually
 	// see the filter example in the example directory for some usage
     filters: [],
-	
-	// set the initial level, no transports are set for levels below the initial settings for performance reasons 
+
+	// set the initial level, no transports are set for levels below the initial settings for performance reasons
 	// the level can be changed later on, but there is no log output if there are no transports set initially
     level: 'debug',
-	
+
 	// the default levels according to RFC 5424, but you can set your own, e.g. ['log', 'info', 'error']
     methods: ['debug', 'info', 'notice', 'warning', 'error', 'critical', 'alert', 'emergency'],
-	
+
 	// get the specified index of stack as file information
     stackIndex: 0  
 };
@@ -187,7 +187,7 @@ let defaultOptions = {
     filename: 'js-logging',
     filenameDateFormat: 'yyyymmdd',
     pathFormat: '${path}/${filename}${filenameDateFormat}.log',
-	
+
 	// set the line ending deliminater for all logging messages
     lineEnding: '\r\n'
 }

--- a/js-logging.es6.js
+++ b/js-logging.es6.js
@@ -273,7 +273,7 @@ function colorText(color, text) {
         default:
             text = color + text; break;
     }
-    return text + '\x1B[39m';
+    return text + '\x1B[39m' + '\x1b[0m';
 };
 
 function Logging(options) {

--- a/js-logging.es6.js
+++ b/js-logging.es6.js
@@ -271,7 +271,7 @@ function colorText(color, text) {
         case 'white':
             text = '\x1B[37m' + text; break;
         default:
-            return text;
+            text = color + text; break;
     }
     return text + '\x1B[39m';
 };
@@ -481,9 +481,9 @@ function logToDailyFile (options) {
         pathFormat: '${path}/${filename}${filenameDateFormat}.log',
         lineEnding: '\r\n'
     };
-    
+
     options = unionOptions(defaultFileOptions, options);
-    
+
     function LogFile(date) {
         let template = assembleFilePath(options.pathFormat);
         date = '.' + date;
@@ -504,7 +504,7 @@ function logToDailyFile (options) {
     let logFile = null;
 
     function dailyFileTransport(data) {
-        
+
         // check time
         let now = dateFormat(new Date(), options.filenameDateFormat);
         if (logFile && logFile.date != now) {
@@ -523,7 +523,7 @@ function logToDailyFile (options) {
     } else {
         options.transport = [dailyFileTransport];
     }
-    
+
     return new Logging(options);
 }
 

--- a/js-logging.umd.js
+++ b/js-logging.umd.js
@@ -279,7 +279,7 @@
             default:
                 text = color + text; break;
         }
-        return text + '\x1B[39m';
+        return text + '\x1B[39m' + '\x1b[0m';
     };
 
     function Logging(options) {

--- a/js-logging.umd.js
+++ b/js-logging.umd.js
@@ -277,7 +277,7 @@
             case 'white':
                 text = '\x1B[37m' + text; break;
             default:
-                return text;
+                text = color + text; break;
         }
         return text + '\x1B[39m';
     };
@@ -487,9 +487,9 @@
             pathFormat: '${path}/${filename}${filenameDateFormat}.log',
             lineEnding: '\r\n'
         };
-        
+
         options = unionOptions(defaultFileOptions, options);
-        
+
         function LogFile(date) {
             let template = assembleFilePath(options.pathFormat);
             date = '.' + date;
@@ -510,7 +510,7 @@
         let logFile = null;
 
         function dailyFileTransport(data) {
-            
+
             // check time
             let now = dateFormat(new Date(), options.filenameDateFormat);
             if (logFile && logFile.date != now) {
@@ -529,7 +529,7 @@
         } else {
             options.transport = [dailyFileTransport];
         }
-        
+
         return new Logging(options);
     }
 

--- a/lib/nodejs/logging.js
+++ b/lib/nodejs/logging.js
@@ -36,7 +36,7 @@ function colorText(color, text) {
         default:
             text = color + text; break;
     }
-    return text + '\x1B[39m';
+    return text + '\x1B[39m' + '\x1b[0m';
 };
 
 function Logging(options) {

--- a/lib/nodejs/logging.js
+++ b/lib/nodejs/logging.js
@@ -34,7 +34,7 @@ function colorText(color, text) {
         case 'white':
             text = '\x1B[37m' + text; break;
         default:
-            return text;
+            text = color + text; break;
     }
     return text + '\x1B[39m';
 };

--- a/test/test.js
+++ b/test/test.js
@@ -53,7 +53,7 @@ describe('simple color message', function() {
 		}
 	});
 	var o = logger.error('hello');
-	it('output', function() { assert.deepEqual(o.output, '\x1B[31mhello\x1B[39m'); });
+	it('output', function() { assert.deepEqual(o.output, '\x1B[31mhello\x1B[39m\u001b[0m'); });
 });
 
 describe('custom format', function() {
@@ -63,7 +63,7 @@ describe('custom format', function() {
 		          {
 		        	  warning : "warning:${message}",
 		        	  error : "error:${message}",
-		          }	
+		          }
 		],
 		transport : function(data) {
 			console.log(data.output);
@@ -75,11 +75,11 @@ describe('custom format', function() {
 		let o = logger.debug('hello world 123');
 		assert.equal(o['output'], 'hello world 123');
 	});
-	it('warning:hello world 123', function() { 
+	it('warning:hello world 123', function() {
 		let o = logger.warning('hello world 123');
 		assert.equal(o['output'], 'warning:hello world 123');
 	});
-	it('error:hello world 123', function() { 
+	it('error:hello world 123', function() {
 		let o = logger.error('hello world 123');
 		assert.equal(o['output'], 'error:hello world 123');
 	});
@@ -92,7 +92,7 @@ describe('custom filter', function() {
 		          {
 		        	  warning : "warning:${message}",
 		        	  error : "error:${message}",
-		          }	
+		          }
 		],
 		filters:[
 		  'black',
@@ -107,17 +107,17 @@ describe('custom filter', function() {
 	});
   {
     let o = logger.debug('hello world 123');
-    it('output debug', function() { assert.equal(o['output'], '\x1B[30mhello world 123\x1B[39m'); });
+    it('output debug', function() { assert.equal(o['output'], '\x1B[30mhello world 123\x1B[39m\u001b[0m'); });
     it('level debug', function() { assert.equal(o['level'], 0); });
   }
   {
     let o = logger.warning('hello world 123');
-    it('output warning', function() { assert.equal(o['output'], '\x1B[34mwarning:hello world 123\x1B[39m'); });
+    it('output warning', function() { assert.equal(o['output'], '\x1B[34mwarning:hello world 123\x1B[39m\u001b[0m'); });
     it('level warning', function() { assert.equal(o['level'], 3); });
   }
   {
     let o = logger.error('hello world 123');
-    it('output error', function() { assert.equal(o['output'], '\x1B[31merror:hello world 123\x1B[39m'); });
+    it('output error', function() { assert.equal(o['output'], '\x1B[31merror:hello world 123\x1B[39m\u001b[0m'); });
     it('level error', function() { assert.equal(o['level'], 4); });
   }
 


### PR DESCRIPTION
As far as I see, there's no flexibility when it comes to customizing the color apart from what is already predefined in a switch.
This PR modifies the default clause to use whatever color string is passed in the config (``\x1b[4m`` for underscore, for example)